### PR TITLE
Auto-unsubscribe all handlers on unmount

### DIFF
--- a/src/__test__/index.test.ts
+++ b/src/__test__/index.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import Swup, { Handler, HookName } from 'swup';
+import BasePlugin from '../index';
+
+declare module 'swup' {
+	export interface HookDefinitions {
+		test: undefined;
+	}
+}
+
+const swup = new Swup();
+swup.hooks.create('test'	as any);
+
+describe('hooks', () => {
+	it('should register and unregister hooks', () => {
+		const handler = vi.fn();
+		const handlerOnce = vi.fn();
+		const handlerReplace = vi.fn();
+		const defaultHandler = vi.fn();
+
+		class Plugin extends BasePlugin {
+			name = 'TestPlugin';
+			mount() {
+				this.on('test', handler);
+				this.once('test', handlerOnce);
+
+				this.swup.hooks.callSync('test' as any, undefined, defaultHandler);
+
+				this.replace('test', handlerReplace);
+
+				this.swup.hooks.callSync('test' as any, undefined, defaultHandler);
+			}
+			unmount() {
+				super.unmount();
+				this.swup.hooks.callSync('test' as any);
+				this.swup.hooks.callSync('test' as any);
+			}
+		}
+
+		const plugin = new Plugin();
+		swup.use(plugin);
+		swup.unuse(plugin);
+		expect(handler).toHaveBeenCalledTimes(2);
+		expect(handlerOnce).toHaveBeenCalledTimes(1);
+		expect(handlerReplace).toHaveBeenCalledTimes(1);
+		expect(defaultHandler).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,7 @@ export default class Plugin implements Omit<PluginType, 'name'> {
 	 * Register a new hook handler. Automatically unsubscribed on unmount.
 	 * @see swup.hooks.on
 	 */
-	on<T extends HookName>(hook: T, handler: Handler<T>, options: HookOptions = {}): Handler<T> {
+	protected on<T extends HookName>(hook: T, handler: Handler<T>, options: HookOptions = {}): Handler<T> {
 		this.handlers.push(() => this.swup.hooks.off(hook, handler));
 		return this.swup.hooks.on(hook, handler, options);
 	}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,6 @@
 import type Swup from 'swup';
-import type { Plugin, HookName, HookOptions, Handler } from 'swup';
+import type { Plugin, HookName, HookOptions, HookUnregister, Handler } from 'swup';
 import { checkDependencyVersion } from './pluginRequirements.js';
-
-type HookUnregister = () => void;
 
 export default abstract class SwupPlugin implements Plugin {
 	/** Name of the plugin */

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,10 @@
 import type Swup from 'swup';
-import type { HookName, HookOptions, Handler } from 'swup';
+import type { Plugin, HookName, HookOptions, Handler } from 'swup';
 import { checkDependencyVersion } from './pluginRequirements.js';
 
 type HookUnregister = () => void;
 
-export default abstract class SwupPlugin {
+export default abstract class SwupPlugin implements Plugin {
 	/** Name of the plugin */
 	abstract name: string;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ export default class Plugin implements Omit<PluginType, 'name'> {
 
 	// Version, not in use
 	version: string | undefined;
+
 	// List of hook handlers, automatically unsubscribed on unmount
 	private handlers: HookUnsubscribe[] = [];
 
@@ -37,6 +38,7 @@ export default class Plugin implements Omit<PluginType, 'name'> {
 
 		// Unsubscribe all registered hook handlers
 		this.handlers.forEach((unsubscribe) => unsubscribe());
+		this.handlers = [];
 	}
 
 	/**
@@ -44,9 +46,8 @@ export default class Plugin implements Omit<PluginType, 'name'> {
 	 * @see swup.hooks.on
 	 */
 	on<T extends HookName>(hook: T, handler: Handler<T>, options: HookOptions = {}): Handler<T> {
-		this.swup.hooks.on(hook, handler, options);
 		this.handlers.push(() => this.swup.hooks.off(hook, handler));
-		return handler;
+		return this.swup.hooks.on(hook, handler, options);
 	}
 
 	_beforeMount() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,16 +41,6 @@ export default class Plugin implements Omit<PluginType, 'name'> {
 		this.handlersToUnregister = [];
 	}
 
-	/**
-	 * Register a new hook handler. Automatically unsubscribed on unmount.
-	 * @see swup.hooks.on
-	 */
-	protected on<T extends HookName>(hook: T, handler: Handler<T>, options: HookOptions = {}): HookUnregister {
-		const unregister = this.swup.hooks.on(hook, handler, options) as HookUnregister;
-		this.handlersToUnregister.push(unregister);
-		return unregister;
-	}
-
 	_beforeMount() {
 		// @ts-ignore name is always defined by extending the Plugin class
 		if (!this.name) {
@@ -77,5 +67,31 @@ export default class Plugin implements Omit<PluginType, 'name'> {
 		});
 
 		return true;
+	}
+
+	/**
+	 * Register a new hook handler. Automatically unsubscribed on unmount.
+	 * @see swup.hooks.on
+	 */
+	protected on<T extends HookName>(hook: T, handler: Handler<T>, options: HookOptions = {}): HookUnregister {
+		const unregister = this.swup.hooks.on(hook, handler, options);
+		this.handlersToUnregister.push(unregister);
+		return unregister;
+	}
+
+	protected once<T extends HookName>(hook: T, handler: Handler<T>, options: HookOptions = {}): HookUnregister {
+		return this.on(hook, handler, { ...options, once: true });
+	}
+
+	protected before<T extends HookName>(hook: T, handler: Handler<T>, options: HookOptions = {}): HookUnregister {
+		return this.on(hook, handler, { ...options, before: true });
+	}
+
+	protected replace<T extends HookName>(hook: T, handler: Handler<T>, options: HookOptions = {}): HookUnregister {
+		return this.on(hook, handler, { ...options, replace: true });
+	}
+
+	protected off<T extends HookName>(hook: T, handler?: Handler<T>): void {
+		return this.swup.hooks.off(hook, handler!);
 	}
 }


### PR DESCRIPTION
**Description**

- Add a new `this.on(hook, handler)` method to allow registering hook handlers
- Also add `this.once`, `this.before`, `this.replace`
- Registered handlers are automatically unsubscribed on `unmount`
- Avoids errors if plugin authors don't keep `mount` and `unmount` methods in sync
- When actually implementing more code in `unmount`, we need to make sure to run `super.unmount()`
- Added unit tests

**Before**

```js
class A11yPlugin {
  mount() {
    this.swup.hooks.on('visit:start', this.markAsBusy);
    this.swup.hooks.before('content:replace', this.announceVisit);
    this.swup.hooks.on('visit:end', this.unmarkAsBusy);
  }
  unmount() {
    this.swup.hooks.off('visit:start', this.markAsBusy);
    this.swup.hooks.off('content:replace', this.announceVisit);
    this.swup.hooks.off('visit:end', this.unmarkAsBusy);
  }
}
```

**After**

```js
class A11yPlugin {
  mount() {
    this.on('visit:start', this.markAsBusy);
    this.before('content:replace', this.announceVisit);
    this.on('visit:end', this.unmarkAsBusy);
  }
}
```