### PR TITLE
Exit with error code on build errors

### DIFF
--- a/bin/lib/shell.js
+++ b/bin/lib/shell.js
@@ -5,8 +5,8 @@ import chalk from 'chalk';
 export function exec(command) {
 	const status = live(command); // shell.exec(command)
 	if (status !== 0) {
-    shell.exit(status);
-  }
+		shell.exit(status);
+	}
 	return status;
 }
 

--- a/bin/lib/shell.js
+++ b/bin/lib/shell.js
@@ -3,8 +3,11 @@ import live from 'shelljs-live';
 import chalk from 'chalk';
 
 export function exec(command) {
-	return live(command);
-	// return shell.exec(command);
+	const status = live(command); // shell.exec(command)
+	if (status !== 0) {
+    shell.exit(status);
+  }
+	return status;
 }
 
 export function echo(message) {

--- a/bin/swup-plugin.js
+++ b/bin/swup-plugin.js
@@ -21,7 +21,7 @@ async function main() {
 
 	const command = args[0] || '';
 	if (!command) {
-		return error(`Missing command (available: ${Object.keys(commands).join(', ')}`);
+		return error(`Missing command (available: ${Object.keys(commands).join(', ')})`);
 	}
 
 	const handler = commands[command];


### PR DESCRIPTION
**Description**

- The current implementation swallows exit codes of subprocesses, e.g. when running microbundle
- This leads to npm publish actions succeeding even when the build step fails
- This PR adds a check for error codes and manually passes them on to the current process

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [ ] ~~New or updated tests are included~~
- [ ] ~~The documentation was updated as required~~

**Additional information**

Closes #27 